### PR TITLE
Korrigerat filnamn för .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,4 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
-© 2019 GitHub, Inc.
+# © 2019 GitHub, Inc.


### PR DESCRIPTION
För att `.gitignore` ska fungera måste filen heta `.gitignore` utan någonting före eller efter, en fil som heter `intro.gitignore` har ingen inverkan på repositoriet.

`git ls-files --ignored --exclude-standard` listar alla filer i repositoriet som är ignorerade, jämförelse före och efter namnbyte:
```
$ git ls-files --ignored --exclude-standard

$ mv intro.gitignore .gitignore

$ git ls-files --ignored --exclude-standard
out/production/klasser/com/klasser/oppgave3.class
out/production/klasser/com/klasser/person.class
```

Tänk på att filerna inte kommer att ignoreras innan de är raderade från repositoriet. När en fil väl ligger där så kommer alla ändringar i den att trackas, det är därför bra att kontrollera vad som läggs med i en commit innan man utför den så man vet att .gitignore-filen fungerar ordentligt. :+1: Med andra ord, kolla alltid `git status` först, och om du råkar stagea filer som du inte vill ha med i committen använd `git restore --staged filnamn`. För just Java vill du t.ex. aldrig ha med filer som slutar på .class då användaren kan skapa dessa själv från källkoden.